### PR TITLE
Add missing requests dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,2 @@
+## 2025-07-17
+- Added `requests` dependency in `pyproject.toml` to ensure tests can import the HTTP library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "requests>=2.0"
+]


### PR DESCRIPTION
## Summary
- add requests dependency to pyproject
- add changelog entry for the dependency update

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'corner_store_scanner')*
- `ruff check . --quiet` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878c985d8c0832ab33a41e5e7e8d041