### PR TITLE
Implement fixes for ScanSession

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,6 @@
 ## 2025-07-17
 - Added `requests` dependency in `pyproject.toml` to ensure tests can import the HTTP library.
+## 2025-07-17
+- Added `total_places_found` to `ScanSession` for accurate session resumption.
+- Updated `LocalFileStorage` to respect patched paths in tests.
+- Corrected integration test mock to return only place lists.

--- a/corner_store_scanner/file_storage.py
+++ b/corner_store_scanner/file_storage.py
@@ -24,10 +24,10 @@ class LocalFileStorage:
         """
         self.config = config
         self.session_id = session_id
-        
-        # Define base data directory
-        self.data_dir = "data"
-        
+
+        # Use class-level defaults so tests can override via patching
+        self.data_dir = self.__class__.data_dir
+
         # Define session-specific directory
         self.session_dir = os.path.join(self.data_dir, self.session_id)
         

--- a/corner_store_scanner/models.py
+++ b/corner_store_scanner/models.py
@@ -68,6 +68,7 @@ class ScanSession:
     hotspot_areas: List[Area] = field(default_factory=list)
     extreme_density_points: List[GridPoint] = field(default_factory=list)
     total_api_calls: int = 0
+    total_places_found: int = 0
     current_cost: float = 0.0
     is_completed: bool = False
 
@@ -88,6 +89,7 @@ class ScanSession:
             'hotspot_areas': [{'center': {'latitude': area.center.latitude, 'longitude': area.center.longitude}, 'radius_km': area.radius_km, 'name': area.name} for area in self.hotspot_areas],
             'extreme_density_points': [{'id': point.id, 'center': {'latitude': point.center.latitude, 'longitude': point.center.longitude}, 'radius': point.radius, 'level': point.level} for point in self.extreme_density_points],
             'total_api_calls': self.total_api_calls,
+            'total_places_found': self.total_places_found,
             'current_cost': self.current_cost,
             'is_completed': self.is_completed
         }
@@ -116,6 +118,7 @@ class ScanSession:
             hotspot_areas=hotspot_areas,
             extreme_density_points=extreme_density_points,
             total_api_calls=data.get('total_api_calls', 0),
+            total_places_found=data.get('total_places_found', 0),
             current_cost=data.get('current_cost', 0.0),
             is_completed=data.get('is_completed', False)
         )

--- a/corner_store_scanner/session_manager.py
+++ b/corner_store_scanner/session_manager.py
@@ -52,7 +52,14 @@ class ScanSessionManager:
                     "longitude": self.config.center_longitude
                 },
                 "radius_km": self.config.scan_radius_km
-            }
+            },
+            "completed_grid_points": [],
+            "hotspot_areas": [],
+            "extreme_density_points": [],
+            "total_api_calls": 0,
+            "total_places_found": 0,
+            "current_cost": 0.0,
+            "is_completed": False
         }
         self.save_session_state(session_id, initial_state)
         return initial_state

--- a/corner_store_scanner/tests/test_integration.py
+++ b/corner_store_scanner/tests/test_integration.py
@@ -87,17 +87,17 @@ class TestIntegration(unittest.TestCase):
 
         # Set the side_effect to return different values on subsequent calls
         mock_nearby_search.side_effect = [
-            (mock_hotspot_response, 1), # First macro call is a hotspot
-            (mock_normal_response, 1),  # Other macro calls are normal
-            (mock_normal_response, 1),
-            (mock_normal_response, 1),
-            (mock_extreme_density_response, 1), # First fine call is extreme density
-            (mock_normal_response, 1), # Other fine calls are normal
-            (mock_enhanced_response, 1), # The enhanced (recursive) call
-            (mock_normal_response, 1), # Subsequent calls
-            (mock_normal_response, 1),
-            (mock_normal_response, 1),
-        ] * 200 # Repeat to ensure we don't run out of mocks
+            mock_hotspot_response,  # First macro call is a hotspot
+            mock_normal_response,  # Other macro calls are normal
+            mock_normal_response,
+            mock_normal_response,
+            mock_extreme_density_response,  # First fine call is extreme density
+            mock_normal_response,  # Other fine calls are normal
+            mock_enhanced_response,  # The enhanced (recursive) call
+            mock_normal_response,  # Subsequent calls
+            mock_normal_response,
+            mock_normal_response,
+        ] * 200  # Repeat to ensure we don't run out of mocks
 
         # --- Phase 1: Run the initial scan ---
         scanner = MainScanner(config=self.config)


### PR DESCRIPTION
## Summary
- add `total_places_found` field to `ScanSession`
- update LocalFileStorage to respect class attributes
- adjust session manager initial state
- fix integration test mocks
- document changes

## Testing
- `python -m unittest discover -s corner_store_scanner/tests` *(fails: test_full_scan_and_resume_flow)*

------
https://chatgpt.com/codex/tasks/task_e_6878cb886fb4832a8aadf3457f427f51