### PR TITLE
Remove duplicate session_dir patches

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,3 @@
 ## 2025-07-17
 - Added `requests` dependency in `pyproject.toml` to ensure tests can import the HTTP library.
+- Removed redundant `session_dir` patches in `test_integration.py`.

--- a/corner_store_scanner/tests/test_integration.py
+++ b/corner_store_scanner/tests/test_integration.py
@@ -41,14 +41,6 @@ class TestIntegration(unittest.TestCase):
         self.session_dir_patcher.start()
         self.addCleanup(self.session_dir_patcher.stop)
 
-        self.session_dir_patcher = patch.object(LocalFileStorage, 'session_dir', os.path.join(self.test_data_dir, 'sessions'))
-        self.session_dir_patcher.start()
-        self.addCleanup(self.session_dir_patcher.stop)
-
-        self.session_dir_patcher = patch.object(LocalFileStorage, 'session_dir', os.path.join(self.test_data_dir, 'sessions'))
-        self.session_dir_patcher.start()
-        self.addCleanup(self.session_dir_patcher.stop)
-
     def tearDown(self):
         """Clean up the test data directory after each test."""
         if os.path.exists(self.test_data_dir):


### PR DESCRIPTION
## Summary
- deduplicate session_dir patch usage in integration tests
- document the cleanup in the changelog

## Testing
- `ruff check .` *(fails: F401, F841, F541, etc.)*
- `PYTHONPATH=. pytest -q` *(fails: AttributeError in integration test)*

------
https://chatgpt.com/codex/tasks/task_e_68791bd07fd8832ab3298984e301c80f