### PR TITLE
Add ScanResult round-trip tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,5 @@
+## 2025-07-18
+- Added tests for `ScanResult` to cover `to_dict` and `from_dict` round-trip behavior.
+
 ## 2025-07-17
 - Added `requests` dependency in `pyproject.toml` to ensure tests can import the HTTP library.

--- a/corner_store_scanner/models.py
+++ b/corner_store_scanner/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Set, Optional, Dict
+from typing import List, Set, Dict
 from datetime import datetime
 
 @dataclass
@@ -140,3 +140,14 @@ class ScanResult:
             'session_id': self.session_id,
             'cost_per_place': self.total_cost / max(self.total_places_found, 1)
         }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'ScanResult':
+        return cls(
+            total_places_found=data['total_places_found'],
+            total_api_calls=data['total_api_calls'],
+            total_cost=data['total_cost'],
+            failed_grid_points=data['failed_grid_points'],
+            scan_duration=data['scan_duration'],
+            session_id=data['session_id'],
+        )

--- a/corner_store_scanner/tests/test_models.py
+++ b/corner_store_scanner/tests/test_models.py
@@ -1,0 +1,36 @@
+import unittest
+from corner_store_scanner.models import ScanResult
+
+
+class TestScanResult(unittest.TestCase):
+    def test_to_dict_round_trip(self):
+        original = ScanResult(
+            total_places_found=5,
+            total_api_calls=10,
+            total_cost=2.5,
+            failed_grid_points=0,
+            scan_duration="1s",
+            session_id="s1",
+        )
+        data = original.to_dict()
+        new_session = ScanResult.from_dict(data)
+        self.assertEqual(new_session.total_places_found, original.total_places_found)
+        self.assertEqual(new_session, original)
+
+    def test_from_dict_preserves_total_places_found(self):
+        original = ScanResult(
+            total_places_found=5,
+            total_api_calls=10,
+            total_cost=2.5,
+            failed_grid_points=0,
+            scan_duration="1s",
+            session_id="s1",
+        )
+        data = original.to_dict()
+        data["total_places_found"] = 42
+        new_result = ScanResult.from_dict(data)
+        self.assertEqual(new_result.total_places_found, 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add from_dict for ScanResult
- test ScanResult to_dict/from_dict round-trip
- document new test in Changelog

## Testing
- `ruff check corner_store_scanner/models.py corner_store_scanner/tests/test_models.py`
- `PYTHONPATH=$PWD pytest -q -k "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_68791bd4d4b8832a8f657512e8eeef3c