### PR TITLE
Add GridPoint ID update logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,3 @@
 ## 2025-07-17
 - Added `requests` dependency in `pyproject.toml` to ensure tests can import the HTTP library.
+- Added `update_id` method to `GridPoint` and now refresh IDs when adjusting grid levels.

--- a/corner_store_scanner/grid_generator.py
+++ b/corner_store_scanner/grid_generator.py
@@ -71,6 +71,7 @@ class GridGenerator:
         for point in grid:
             point.level = 1
             point.radius = self.config.MACRO_SEARCH_RADIUS
+            point.update_id()
         return grid
 
     def generate_fine_grid(self, hotspot_areas: List[Area]) -> List[GridPoint]:
@@ -84,6 +85,7 @@ class GridGenerator:
             for point in grid:
                 point.level = 2
                 point.radius = self.config.FINE_SEARCH_RADIUS
+                point.update_id()
             all_fine_points.extend(grid)
         # Deduplicate points in case hotspot areas overlap
         # A simple approach is to use a dictionary, which preserves order in Python 3.7+
@@ -101,7 +103,8 @@ class GridGenerator:
         for point in grid:
             point.level = extreme_density_point.level + 1
             point.radius = new_radius
-            
+            point.update_id()
+
         return grid
 
     def should_recurse(self, result_count: int, current_level: int) -> bool:

--- a/corner_store_scanner/models.py
+++ b/corner_store_scanner/models.py
@@ -18,7 +18,11 @@ class GridPoint:
     id: str = field(init=False)
 
     def __post_init__(self):
-        self.id = f"grid_{self.level}_{self.center.latitude}_{self.center.longitude}"
+        self.update_id()
+
+    def update_id(self) -> None:
+        """Regenerate the grid point identifier."""
+        self.id = f"grid_{self.level}_{self.center.latitude}_{self.center.longitude}_{self.radius}"
 
 @dataclass
 class Area:

--- a/corner_store_scanner/tests/test_grid.py
+++ b/corner_store_scanner/tests/test_grid.py
@@ -75,6 +75,7 @@ class TestGridGenerator(unittest.TestCase):
         # Check that level and radius are set correctly
         self.assertEqual(grid[0].level, 1)
         self.assertEqual(grid[0].radius, self.config.MACRO_SEARCH_RADIUS)
+        self.assertTrue(grid[0].id.startswith("grid_1_"))
 
     def test_generate_fine_grid(self):
         """Test the generation of a fine-grained grid from hotspots."""
@@ -83,6 +84,7 @@ class TestGridGenerator(unittest.TestCase):
         self.assertTrue(len(grid) > 0)
         self.assertEqual(grid[0].level, 2)
         self.assertEqual(grid[0].radius, self.config.FINE_SEARCH_RADIUS)
+        self.assertTrue(grid[0].id.startswith("grid_2_"))
 
     def test_generate_enhanced_grid(self):
         """Test the generation of an enhanced grid for recursion."""
@@ -91,6 +93,7 @@ class TestGridGenerator(unittest.TestCase):
         self.assertTrue(len(grid) > 0)
         self.assertEqual(grid[0].level, 3)
         self.assertEqual(grid[0].radius, 250)
+        self.assertTrue(grid[0].id.startswith("grid_3_"))
 
     def test_should_recurse(self):
         """Test the logic for triggering recursion."""


### PR DESCRIPTION
## Summary
- regenerate grid point IDs when level or radius changes
- call the update method in `GridGenerator`
- check ID prefixes in unit tests
- document change in `Changelog.md`

## Testing
- `ruff check .`
- `python -m unittest discover -s corner_store_scanner/tests` *(fails: AttributeError in integration test)*

------
https://chatgpt.com/codex/tasks/task_e_68791bd7bb38832ab4ca644f8242aaa7